### PR TITLE
Yelp Stats Workflow

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -47,3 +47,18 @@ action "Alias" {
   secrets = ["ZEIT_TOKEN"]
   needs = ["Master"]
 }
+
+workflow "Yelp Stats" {
+  on = "repository_dispatch"
+  resolves = ["HTTPie Test", "cURL Test"]
+}
+
+action "HTTPie Test" {
+  uses = "swinton/httpie.action@master"
+  args = "http://example.com/"
+}
+
+action "cURL Test" {
+  uses = "actions/bin/curl@master"
+  args = "http://example.com/"
+}


### PR DESCRIPTION
Repository dispatch events are being sent successfully, but for some reason are not triggering the repository dispatch event that this workflow is wired up to.  Maybe the workflow needs to be merged to master for it to work.